### PR TITLE
Add awards group migration to public vote branch

### DIFF
--- a/frontend/components/CategoryInfo.vue
+++ b/frontend/components/CategoryInfo.vue
@@ -25,6 +25,22 @@
 				<p class="help">What type of entries can be included in this category</p>
 			</div>
 			<div class="field">
+				<label class="label">Awards Group</label>
+				<div class="control">
+					<div class="select">
+					<select v-model="newEntryGroup">
+						<option disabled>Select one</option>
+						<option value="genre">Genre Awards</option>
+						<option value="character">Character Awards</option>
+						<option value="production">Production Awards</option>
+						<option value="test">Test Category</option>
+						<option value="main">Main Awards</option>
+					</select>
+					</div>
+				</div>
+				<p class="help">What Awards Group this category belongs to (Genre, Character, Production)</p>
+			</div>
+			<div class="field">
 				<div class="control">
 					<button
 						type="submit"
@@ -47,6 +63,7 @@ export default {
 		return {
 			newCategoryName: this.category.name,
 			newEntryType: this.category.entryType,
+			newEntryGroup: this.category.awardsGroup,
 			submitting: false,
 		};
 	},
@@ -66,6 +83,7 @@ export default {
 						data: {
 							name: this.newCategoryName,
 							entryType: this.newEntryType,
+							awardsGroup: this.newEntryGroup,
 						},
 					});
 				} finally {

--- a/frontend/pages/host/AllCategories.vue
+++ b/frontend/pages/host/AllCategories.vue
@@ -49,6 +49,9 @@
 								<span class="tag">{{categoryEntryType(category)}}</span>
 							</div>
 							<div class="level-item">
+								<span class="tag">{{categoryGroup(category)}}</span>
+							</div>
+							<div class="level-item">
 								<router-link
 									:to="{name: 'categoryEntries', params: {categoryId: category.id}}"
 									class="tag"
@@ -71,7 +74,7 @@
 							<div class="level-item">
 								<button class="button is-info"
 								v-bind:class="{'is-loading' : duplicating && category.id === selectedCategoryId}"
-								@click="submitDuplicateCategory(category.id, category.name, category.entryType, category.entries)">
+								@click="submitDuplicateCategory(category.id, category.name, category.entryType, category.entries, category.group)">
 								Copy
 								</button>
 							</div>
@@ -98,7 +101,7 @@
 				<div class="field">
 					<label class="label">Name</label>
 					<div class="control">
-						<input class="input" type="text" v-model="categoryName" placeholder="Genre Awards"/>
+						<input class="input" type="text" v-model="categoryName" placeholder="Action, Animation, AotY..."/>
 					</div>
 				</div>
 				<div class="field">
@@ -111,6 +114,21 @@
 							<option value="characters">Characters</option>
 							<option value="vas">VA Performances</option>
 							<option value="themes">OPs/EDs</option>
+						</select>
+						</div>
+					</div>
+				</div>
+				<div class="field">
+					<label class="label">Awards Group</label>
+					<div class="control">
+						<div class="select">
+						<select v-model="newEntryGroup">
+							<option disabled>Select one</option>
+							<option value="genre">Genre Awards</option>
+							<option value="character">Character Awards</option>
+							<option value="production">Production Awards</option>
+							<option value="test">Test Category</option>
+							<option value="main">Main Awards</option>
 						</select>
 						</div>
 					</div>
@@ -141,6 +159,7 @@ export default {
 			createCategoryOpen: false,
 			categoryName: '',
 			newEntryType: 'shows',
+			newEntryGroup: 'genre',
 			submitting: false,
 			deleting: false,
 			duplicating: false,
@@ -163,7 +182,6 @@ export default {
 	methods: {
 		...mapActions([
 			'getCategories',
-			'getGroups',
 			'createCategory',
 			'deleteCategory',
 		]),
@@ -182,33 +200,42 @@ export default {
 				default: return 'Unknown entry type';
 			}
 		},
-		submitDeleteCategory(categoryID) {
+		categoryGroup (category) {
+			switch (category.awardsGroup) {
+				case 'genre': return 'Genre Awards';
+				case 'character': return 'Character Awards';
+				case 'production': return 'Production Awards';
+				case 'test': return 'Test Category';
+				case 'main': return 'Main Awards';
+				default: return 'Unknown Group';
+			}
+		},
+		submitDeleteCategory (categoryID) {
 			this.deleting = true;
 			this.selectedCategoryId = categoryID;
 			setTimeout(async () => {
 				try {
 					await this.deleteCategory(categoryID);
-				}
-				finally {
+				} finally {
 					this.deleting = false;
 				}
 			});
 		},
-		submitDuplicateCategory(categoryID, categoryName, categoryType, categoryEntries) {
+		submitDuplicateCategory (categoryID, categoryName, categoryType, categoryEntries, categoryGroup) {
 			this.duplicating = true;
 			this.selectedCategoryId = categoryID;
-			var newName = categoryName + " copy";
+			const newName = `${categoryName} copy`;
 			setTimeout(async () => {
 				try {
 					await this.createCategory({
 						data: {
 							name: newName,
 							entryType: categoryType,
-							entries: categoryEntries
-						}
+							entries: categoryEntries,
+							awardsGroup: categoryGroup,
+						},
 					});
-				}
-				finally {
+				} finally {
 					this.duplicating = false;
 				}
 			});
@@ -222,11 +249,11 @@ export default {
 						data: {
 							name: this.categoryName,
 							entryType: this.newEntryType,
-							entries: "",
+							entries: '',
+							awardsGroup: this.newEntryGroup,
 						},
 					});
-				}
-				finally {
+				} finally {
 					this.createCategoryOpen = false;
 					this.submitting = false;
 				}

--- a/frontend/pages/host/AllCategories.vue
+++ b/frontend/pages/host/AllCategories.vue
@@ -74,7 +74,7 @@
 							<div class="level-item">
 								<button class="button is-info"
 								v-bind:class="{'is-loading' : duplicating && category.id === selectedCategoryId}"
-								@click="submitDuplicateCategory(category.id, category.name, category.entryType, category.entries, category.group)">
+								@click="submitDuplicateCategory(category.id, category.name, category.entryType, category.entries, category.awardsGroup)">
 								Copy
 								</button>
 							</div>

--- a/migrations/20191224123436-group-categories.js
+++ b/migrations/20191224123436-group-categories.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.addColumn('categories', 'awardsGroup', {
+    type: 'string',
+    notNull: true,
+    defaultValue: 'genre',
+  });
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/util/db.js
+++ b/util/db.js
@@ -37,7 +37,15 @@ db.exec(`
 		entries
 			TEXT
 			NOT NULL
-			DEFAULT ''
+			DEFAULT '',
+		active
+			INTEGER
+			NOT NULL
+			DEFAULT 1
+		awardsGroup
+			TEXT
+			NOT NULL
+			DEFAULT 'genre',
 	);
 	CREATE TABLE IF NOT EXISTS themes (
 		id
@@ -63,6 +71,25 @@ db.exec(`
 			TEXT
 			DEFAULT ''
 	);
+	CREATE TABLE IF NOT EXISTS public-votes (
+		id
+			INTEGER
+			PRIMARY KEY
+			AUTOINCREMENT,
+		reddit_user
+			TEXT
+			NOT NULL,
+		user_id
+			INTEGER,
+		category_id
+			INTEGER
+			NOT NULL,
+		entry_id
+			INTEGER
+			NOT NULL,
+		anilist_id
+			INTEGER
+	);
 `);
 */
 
@@ -75,8 +102,8 @@ const deleteUserQuery = db.prepare('DELETE FROM users WHERE reddit=?');
 const getCategoryQuery = db.prepare('SELECT * FROM categories WHERE id=? AND active=1');
 const getCategoryByRowidQuery = db.prepare('SELECT * FROM categories WHERE rowid=? AND active=1');
 const getAllCategoriesQuery = db.prepare('SELECT * FROM categories WHERE active=1');
-const insertCategoryQuery = db.prepare('INSERT INTO categories (name,entryType,entries) VALUES (:name,:entryType,:entries)');
-const updateCategoryQuery = db.prepare('UPDATE categories SET name=:name, entryType=:entryType, entries=:entries WHERE id=:id');
+const insertCategoryQuery = db.prepare('INSERT INTO categories (name,entryType,entries,awardsGroup) VALUES (:name,:entryType,:entries,:awardsGroup)');
+const updateCategoryQuery = db.prepare('UPDATE categories SET name=:name, entryType=:entryType, entries=:entries, awardsGroup=:awardsGroup WHERE id=:id');
 const deleteCategoryQuery = db.prepare('UPDATE categories SET active=0 WHERE id=?');
 
 const getAllThemesQuery = db.prepare('SELECT * FROM themes');


### PR DESCRIPTION
This should allow us to record the category group in the DB. Run `db-migrate up` to add the column. The commented create statement has also been updated in case stuff goes wrong (which it inevitably will) since `db-migrate reset` is some nasty business.