### PR TITLE
remove anilist image links from character cats

### DIFF
--- a/frontend/data/results2017.json
+++ b/frontend/data/results2017.json
@@ -970,7 +970,7 @@
       {
        "id": 22036,
        "altname": "Koyomi Araragi",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b22036-Ed3CjwPlDLp4.png",
+       "altimg": "",
        "public": 228,
        "finished": 788,
        "support": 0.2893401015228426,
@@ -994,7 +994,7 @@
       {
        "id": 21044,
        "altname": "Rei Kiriyama",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/21044-14X5wgaC9Dvk.jpg",
+       "altimg": "",
        "public": 247,
        "finished": 871,
        "support": 0.2835820895522388,
@@ -1006,7 +1006,7 @@
       {
        "id": 80243,
        "altname": "Shouko Nishimiya",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b80243-IulaT2p4MrKw.png",
+       "altimg": "",
        "public": 280,
        "finished": 1079,
        "support": 0.2594995366079703,
@@ -1062,7 +1062,7 @@
       {
        "id": 14278,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/14278-68R0da0yQg0P.png",
+       "altimg": "",
        "public": 81,
        "finished": 428,
        "support": 0.18925233644859812,
@@ -1074,7 +1074,7 @@
       {
        "id": 120890,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/120890-fDi4AMeJRsIX.png",
+       "altimg": "",
        "public": 172,
        "finished": 952,
        "support": 0.18067226890756302,
@@ -1086,7 +1086,7 @@
       {
        "id": 89362,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b89362-ksvcFYL0VkfR.jpg",
+       "altimg": "",
        "public": 192,
        "finished": 1556,
        "support": 0.12339331619537275,
@@ -1098,7 +1098,7 @@
       {
        "id": 81645,
        "altname": "Akko",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/81645-dvD1Ac67IkpJ.png",
+       "altimg": "",
        "public": 197,
        "finished": 1219,
        "support": 0.1616078753076292,
@@ -1110,7 +1110,7 @@
       {
        "id": 89361,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/89361-cn51JONrX4SG.jpg",
+       "altimg": "",
        "public": 240,
        "finished": 1556,
        "support": 0.15424164524421594,
@@ -1122,7 +1122,7 @@
       {
        "id": 89364,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b89364-fXjaaE29T2Dx.jpg",
+       "altimg": "",
        "public": 774,
        "finished": 1556,
        "support": 0.4974293059125964,
@@ -1160,7 +1160,7 @@
       {
        "id": 70293,
        "altname": "Kyouko Kouda",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b70293-5gBfljTGozfE.png",
+       "altimg": "",
        "public": 42,
        "finished": 698,
        "support": 0.06017191977077364,
@@ -1172,7 +1172,7 @@
       {
        "id": 89707,
        "altname": "Konatsu",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/89707-VkWbarPuNi0N.jpg",
+       "altimg": "",
        "public": 143,
        "finished": 479,
        "support": 0.2985386221294363,
@@ -1184,7 +1184,7 @@
       {
        "id": 89335,
        "altname": "Yuzuru Nishimiya",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b89335-3fy5a7Qa9h9J.jpg",
+       "altimg": "",
        "public": 158,
        "finished": 834,
        "support": 0.18944844124700239,
@@ -1196,7 +1196,7 @@
       {
        "id": 124307,
        "altname": "Antarcticite",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b124307-SlmWpLIanBkU.png",
+       "altimg": "",
        "public": 165,
        "finished": 763,
        "support": 0.2162516382699869,
@@ -1208,7 +1208,7 @@
       {
        "id": 124740,
        "altname": "Kai Shimada",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b124740-Rsse916qp1Y8.jpg",
+       "altimg": "",
        "public": 202,
        "finished": 698,
        "support": 0.28939828080229224,
@@ -1220,7 +1220,7 @@
       {
        "id": 122445,
        "altname": "Nanachi",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b122445-5uDu8wMy8Jxi.png",
+       "altimg": "",
        "public": 389,
        "finished": 946,
        "support": 0.41120507399577166,
@@ -1264,7 +1264,7 @@
       {
        "id": 23510,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b23510-MDOriMvld5Ra.jpg",
+       "altimg": "",
        "public": 94,
        "finished": 288,
        "support": 0.3263888888888889,
@@ -1276,7 +1276,7 @@
       {
        "id": 123295,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n123295-VUPSwVdr3euW.png",
+       "altimg": "",
        "public": 152,
        "finished": 720,
        "support": 0.2111111111111111,
@@ -1288,7 +1288,7 @@
       {
        "id": 89647,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b89647-U0cfS16kuvIr.png",
+       "altimg": "",
        "public": 181,
        "finished": 647,
        "support": 0.2797527047913447,
@@ -1300,7 +1300,7 @@
       {
        "id": 70297,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n70297-UiQFeSaB7HKD.png",
+       "altimg": "",
        "public": 206,
        "finished": 612,
        "support": 0.3366013071895425,
@@ -1312,7 +1312,7 @@
       {
        "id": 120971,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/120971-AXg7p7a53QNz.jpg",
+       "altimg": "",
        "public": 221,
        "finished": 970,
        "support": 0.22783505154639175,
@@ -1387,7 +1387,7 @@
       {
        "id": 121871,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b121871-MPD2bPKxc7zU.jpg",
+       "altimg": "",
        "public": 26,
        "finished": 173,
        "support": 0.15028901734104047,
@@ -1399,7 +1399,7 @@
       {
        "id": 120991,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/120991-TSmsV1XNNIfF.png",
+       "altimg": "",
        "public": 144,
        "finished": 741,
        "support": 0.19433198380566802,
@@ -1411,7 +1411,7 @@
       {
        "id": 122463,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b122463-JPYNgw7j5dB4.png",
+       "altimg": "",
        "public": 201,
        "finished": 1102,
        "support": 0.1823956442831216,
@@ -1423,7 +1423,7 @@
       {
        "id": 87886,
        "altname": "",
-       "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b87886-ZRBtKp5Sjoaa.png",
+       "altimg": "",
        "public": 412,
        "finished": 722,
        "support": 0.5706371191135734,

--- a/frontend/data/results2018.json
+++ b/frontend/data/results2018.json
@@ -1113,7 +1113,7 @@
        {
         "id": 127808,
         "altname": "Koharu Hidaka",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b127808-DXOhr30Y4S9U.jpg",
+        "altimg": "",
         "public": 29,
         "finished": 413,
         "support": 0.07021791767554479,
@@ -1161,7 +1161,7 @@
        {
         "id": 127222,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b127222-IY5iDRuXLY8i.png",
+        "altimg": "",
         "public": 138,
         "finished": 1121,
         "support": 0.12310437109723461,
@@ -1173,7 +1173,7 @@
        {
         "id": 127221,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n127221-Wxg4xFtW4kaJ.png",
+        "altimg": "",
         "public": 242,
         "finished": 1121,
         "support": 0.215878679750223,
@@ -1185,7 +1185,7 @@
        {
         "id": 90169,
         "altname": "Violet Evergarden",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b90169-q5lmES4WWGuV.png",
+        "altimg": "",
         "public": 264,
         "finished": 1070,
         "support": 0.2467289719626168,
@@ -1197,7 +1197,7 @@
        {
         "id": 124546,
         "altname": "Shirase Kobuchizawa",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b124546-LuynSTimOdvY.png",
+        "altimg": "",
         "public": 379,
         "finished": 959,
         "support": 0.39520333680917624,
@@ -1345,7 +1345,7 @@
        {
         "id": 126953,
         "altname": "Nozomi Takamagahara",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/126953-76diolflZNea.jpg",
+        "altimg": "",
         "public": 18,
         "finished": 360,
         "support": 0.05,
@@ -1357,7 +1357,7 @@
        {
         "id": 129090,
         "altname": "Ririka Kenzaki",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n129090-G6aioIfAlDTk.png",
+        "altimg": "",
         "public": 20,
         "finished": 328,
         "support": 0.06097560975609756,
@@ -1369,7 +1369,7 @@
        {
         "id": 124554,
         "altname": "Gin Toudou",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b124554-jB7ke4JrybC0.png",
+        "altimg": "",
         "public": 30,
         "finished": 873,
         "support": 0.03436426116838488,
@@ -1393,7 +1393,7 @@
        {
         "id": 127633,
         "altname": "Rio Futaba",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n127633-8DCP7D1NRHKK.jpg",
+        "altimg": "",
         "public": 105,
         "finished": 984,
         "support": 0.10670731707317073,
@@ -1405,7 +1405,7 @@
        {
         "id": 127613,
         "altname": "Kaede Azusagawa",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n127613-Lb9CWr0Yk1Me.jpg",
+        "altimg": "",
         "public": 233,
         "finished": 984,
         "support": 0.23678861788617886,
@@ -1417,7 +1417,7 @@
        {
         "id": 124547,
         "altname": "Hinata Miyake",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n124547-6nbhiholxEve.jpg",
+        "altimg": "",
         "public": 245,
         "finished": 873,
         "support": 0.2806414662084765,
@@ -1576,7 +1576,7 @@
        {
         "id": 132720,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n132720-gyeac9EfQK4D.jpg",
+        "altimg": "",
         "public": 13,
         "finished": 501,
         "support": 0.02594810379241517,
@@ -1588,7 +1588,7 @@
        {
         "id": 127574,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n127574-rB5zXFZ98kAh.jpg",
+        "altimg": "",
         "public": 48,
         "finished": 659,
         "support": 0.07283763277693475,
@@ -1600,7 +1600,7 @@
        {
         "id": 127443,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/127443-aVMXGOchpsvj.png",
+        "altimg": "",
         "public": 155,
         "finished": 806,
         "support": 0.19230769230769232,
@@ -1612,7 +1612,7 @@
        {
         "id": 125956,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/125956-jzhb8Z4peLb8.jpg",
+        "altimg": "",
         "public": 158,
         "finished": 936,
         "support": 0.16880341880341881,
@@ -1624,7 +1624,7 @@
        {
         "id": 4092,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/b4092-63yxC7cCrWke.png",
+        "altimg": "",
         "public": 167,
         "finished": 656,
         "support": 0.2545731707317073,
@@ -1636,7 +1636,7 @@
        {
         "id": 125442,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n125442-GDTpp4NTgM0E.png",
+        "altimg": "",
         "public": 206,
         "finished": 536,
         "support": 0.3843283582089552,
@@ -1648,7 +1648,7 @@
        {
         "id": 127587,
         "altname": "",
-        "altimg": "https://s4.anilist.co/file/anilistcdn/character/large/n127587-aOCWfkp0BjNK.jpg",
+        "altimg": "",
         "public": 343,
         "finished": 773,
         "support": 0.44372574385511,


### PR DESCRIPTION
Anilist image hotlinks appear unnecessarily in 2017 and 2018 character cats. This removes them.