### PR TITLE
Replace Chika image

### DIFF
--- a/frontend/data/results2019.json
+++ b/frontend/data/results2019.json
@@ -3022,7 +3022,7 @@
          {
           "id": 121103,
           "altname": "",
-          "altimg": "https://i.imgur.com/UPDQ1W2.png",
+          "altimg": "https://i.imgur.com/OYP3TX8.jpg",
           "public": 84,
           "finished": 671,
           "support": 0.12518628912071536,


### PR DESCRIPTION
old image was watermarked, new image is half the size (in KB) and cleaner